### PR TITLE
Make 'container' element follow 'overlay' rather than being nested within it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "svelte-micromodal",
       "version": "0.0.8",
       "dependencies": {
-        "micromodal": "0.4.8"
+        "micromodal": "^0.4.10"
       },
       "devDependencies": {
         "@sveltejs/adapter-static": "next",
@@ -2307,9 +2307,9 @@
       }
     },
     "node_modules/micromodal": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/micromodal/-/micromodal-0.4.8.tgz",
-      "integrity": "sha512-Yp4t4QF7Vpi8F9z+Kzrq+BKlTGTb57Z945S0BjlDHjZSG2WaKm8+14Rh4/xzsa1CrM56Ayp93if0pHJy9uqPYg==",
+      "version": "0.4.10",
+      "resolved": "https://registry.npmjs.org/micromodal/-/micromodal-0.4.10.tgz",
+      "integrity": "sha512-BUrEnzMPFBwK8nOE4xUDYHLrlGlLULQVjpja99tpJQPSUEWgw3kTLp1n1qv0HmKU29AiHE7Y7sMLiRziDK4ghQ==",
       "engines": {
         "node": ">=10"
       }
@@ -4982,9 +4982,9 @@
       }
     },
     "micromodal": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/micromodal/-/micromodal-0.4.8.tgz",
-      "integrity": "sha512-Yp4t4QF7Vpi8F9z+Kzrq+BKlTGTb57Z945S0BjlDHjZSG2WaKm8+14Rh4/xzsa1CrM56Ayp93if0pHJy9uqPYg=="
+      "version": "0.4.10",
+      "resolved": "https://registry.npmjs.org/micromodal/-/micromodal-0.4.10.tgz",
+      "integrity": "sha512-BUrEnzMPFBwK8nOE4xUDYHLrlGlLULQVjpja99tpJQPSUEWgw3kTLp1n1qv0HmKU29AiHE7Y7sMLiRziDK4ghQ=="
     },
     "min-indent": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
   },
   "type": "module",
   "dependencies": {
-    "micromodal": "0.4.8"
+    "micromodal": "0.4.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "svelte-micromodal",
   "description": "Svelte wrapper around Micromodal to create light, accessible modal dialogs",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "scripts": {
     "dev": "svelte-kit dev",
     "build": "svelte-kit build",

--- a/src/lib/Modal.svelte
+++ b/src/lib/Modal.svelte
@@ -65,35 +65,27 @@
     class="mm-overlay"
     tabindex="-1"
     style={overlayStyles || undefined}
-    data-micromodal-close
-  >
-    <div
-      class="mm-container"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby={`${id}-title`}
-      style={containerStyles || undefined}
-    >
-      <header class="mm-header" style={headerStyles || undefined}>
-        <h2
-          class="mm-title"
-          id={`${id}-title`}
-          style={titleStyles || undefined}
-        >
-          {title}
-        </h2>
-        <!-- we need to use the data attribute here to avoid the close button from getting focused as the first interactive element in the modal -->
-        <button
-          class="mm-close"
-          style={closeStyles || undefined}
-          data-micromodal-close
-        >
-          {@html closeIcon}
-          <span class="sr-only">{closeLabel}</span>
-        </button>
-      </header>
-      <slot />
-    </div>
+    data-micromodal-close />
+  <div
+    class="mm-container"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby={`${id}-title`}
+    style={containerStyles || undefined}>
+    <header class="mm-header" style={headerStyles || undefined}>
+      <h2 class="mm-title" id={`${id}-title`} style={titleStyles || undefined}>
+        {title}
+      </h2>
+      <!-- we need to use the data attribute here to avoid the close button from getting focused as the first interactive element in the modal -->
+      <button
+        class="mm-close"
+        style={closeStyles || undefined}
+        data-micromodal-close>
+        {@html closeIcon}
+        <span class="sr-only">{closeLabel}</span>
+      </button>
+    </header>
+    <slot />
   </div>
 </div>
 
@@ -114,12 +106,13 @@
     right: 0;
     bottom: 0;
     background: rgba(0, 0, 0, 0.5);
-    display: flex;
-    justify-content: center;
-    align-items: center;
   }
 
   .mm-container {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
     background-color: white;
     padding: 24px;
     width: 512px;


### PR DESCRIPTION
This is a workaround for an issue in the underlying `micromodal` library, present in version `0.4.10`.

Upgrading from `0.4.8` to `0.4.10` is desirable, as it fixes an issue where a click to dismiss the Overlay propagates through to any underlying clickable elements.

This should fix #6.

Further notes on the changes are added as inline PR comments.